### PR TITLE
Fix to allow the form to load in IE

### DIFF
--- a/Block/Widget/Form.php
+++ b/Block/Widget/Form.php
@@ -60,7 +60,7 @@ class Form extends \Magento\Framework\View\Element\Template implements \Magento\
 	 */
 	public function getSrc()
     {
-		return "//" . $this->baseUrl . "/js/forms2/js/forms2.min.js";
+		return $this->baseUrl . "/js/forms2/js/forms2.min.js";
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you **don't** have Pyxl_Core installed already run this first:
 Then require this package:
 
     composer config repositories.pyxl-marketowidget git https://github.com/thinkpyxl/magento2-Pyxl_MarketoWidget.git
-    composer require pyxl/marketo-widget:^1.0.3
+    composer require pyxl/marketo-widget:^1.0.4
     bin/magento module:enable Pyxl_MarketoWidget
     bin/magento setup:upgrade
     bin/magento cache:clean 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "magento/magento-composer-installer": "*"
   },
   "type": "magento2-module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
IE struggled with "////", while Chrome and FF both just assumed we meant "//". This fix allows forms2.min.js to load, so that the rest of the script can execute.